### PR TITLE
Add canadian tide information with some refactoring

### DIFF
--- a/clients/chs_client.rb
+++ b/clients/chs_client.rb
@@ -1,0 +1,80 @@
+require './data_models/station'
+require 'pry'
+module Clients
+    class ChsClient
+        API_URL = 'https://api-iwls.dfo-mpo.gc.ca/api/v1'
+        attr :logger
+
+        def initialize(logger)
+            @logger = logger
+        end
+
+        def tide_stations
+            url = "#{API_URL}/stations"
+            agent = Mechanize.new
+            logger.info "getting tide station list from #{url}"
+            json = agent.get(url).body
+            logger.debug "json.length = #{json.length}"
+
+
+            logger.debug "parsing tide station list"
+            data = JSON.parse(json) rescue []
+
+            stations = data.map do |js|
+                DataModels::Station.new(
+                    name: js['officialName'],
+                    alternate_names: [],
+                    id: js['id'],
+                    public_id: js['code'],
+                    region: region_for(js['latitude'], js['longitude']),
+                    location: [js["officialName"], "Canada"].join(", "),
+                    lat: js['latitude'],
+                    lon: js['longitude'],
+                    url: "https://www.tides.gc.ca/en/stations/#{js['code']}",
+                    provider: 'chs'
+                )
+            end
+            return stations
+        end
+
+        def region_for(lat, long)
+            if long < -75 && long > -96 && lat < 64 && lat > 51
+                'Hudson\'s Bay, Canada'
+            elsif lat > 60
+                'Northern Canada'
+            elsif long < -120
+                'Pacific Canada'
+            elsif long > -75
+                'Atlantic Canada'
+            else
+                'Canada'
+            end
+        end
+
+        def tide_data_for(station, year, public_id)
+            agent = Mechanize.new
+            url = "#{API_URL}/stations/#{station}/data?time-series-code=wlp-hilo&from=#{year-1}-12-31T15:00:00Z&to=#{year}-12-31T23:59:59Z"
+
+            logger.info "getting json from #{url}"
+            json = agent.get(url).body
+            logger.debug "json.length = #{json.length}"
+
+            logger.debug "parsing tide station list"
+            data = JSON.parse(json) rescue []
+            prev_value = data[1]['value']
+
+            data.map do |jt|
+                time = DateTime.parse(jt["eventDate"])
+                td = DataModels::TideData.new(
+                    type: jt['value'] >= prev_value ? "High" : "Low",
+                    units: "m",
+                    prediction: jt["value"],
+                    time: time,
+                    url: "https://www.tides.gc.ca/en/stations/#{public_id}/#{time.strftime("%Y-%m-%d")}"
+                )
+                prev_value = td.prediction
+                td
+            end
+        end
+    end
+end

--- a/clients/chs_client.rb
+++ b/clients/chs_client.rb
@@ -1,5 +1,6 @@
-require './data_models/station'
-require './data_models/tide_data'
+require_relative '../data_models/station'
+require_relative '../data_models/tide_data'
+
 module Clients
     class ChsClient
         API_URL = 'https://api-iwls.dfo-mpo.gc.ca/api/v1'

--- a/clients/chs_client.rb
+++ b/clients/chs_client.rb
@@ -1,5 +1,5 @@
 require './data_models/station'
-require 'pry'
+require './data_models/tide_data'
 module Clients
     class ChsClient
         API_URL = 'https://api-iwls.dfo-mpo.gc.ca/api/v1'

--- a/clients/noaa_client.rb
+++ b/clients/noaa_client.rb
@@ -1,6 +1,6 @@
 require './data_models/station'
 require './data_models/tide_data'
-require 'pry'
+
 module Clients
     class NoaaClient
         API_URL = 'https://api.tidesandcurrents.noaa.gov'

--- a/clients/noaa_client.rb
+++ b/clients/noaa_client.rb
@@ -1,5 +1,5 @@
-require './data_models/station'
-require './data_models/tide_data'
+require_relative '../data_models/station'
+require_relative '../data_models/tide_data'
 
 module Clients
     class NoaaClient

--- a/clients/noaa_client.rb
+++ b/clients/noaa_client.rb
@@ -1,0 +1,65 @@
+require './data_models/station'
+require './data_models/tide_data'
+require 'pry'
+module Clients
+    class NoaaClient
+        API_URL = 'https://api.tidesandcurrents.noaa.gov'
+        attr :logger
+
+        def initialize(logger)
+            @logger = logger
+        end
+
+        def tide_stations
+            url = "#{API_URL}/mdapi/prod/webapi/tidepredstations.json?q="
+            agent = Mechanize.new
+            logger.info "getting tide station list from #{url}"
+            json = agent.get(url).body
+            logger.debug "json.length = #{json.length}"
+
+
+            logger.debug "parsing tide station list"
+            data = JSON.parse(json)["stationList"] rescue []
+
+            stations = data.map do |js|
+                DataModels::Station.new(
+                    name: js['name'],
+                    alternate_names: [js['etidesStnName'], js['commonName'], js['stationFullName']],
+                    id: js['stationId'],
+                    public_id: js['stationId'],
+                    region: js['region'],
+                    location: [js["etidesStnName"], js["region"], js["state"]].join(", "),
+                    lat: js['lat'],
+                    lon: js['lon'],
+                    url: "https://tidesandcurrents.noaa.gov/stationhome.html?id=#{js['stationId']}",
+                    provider: 'noaa'
+                )
+            end
+            return stations
+        end
+
+        def tide_data_for(station, year, public_id)
+            agent = Mechanize.new
+            url = "#{API_URL}/api/prod/datagetter?product=predictions&datum=MLLW&time_zone=gmt&interval=hilo&units=english&application=web_services&format=json&begin_date=#{year}0101&end_date=#{year}1231&station=#{station}"
+
+            logger.info "getting json from #{url}"
+            json = agent.get(url).body
+            logger.debug "json.length = #{json.length}"
+
+
+            logger.debug "parsing tide station list"
+            data = JSON.parse(json)["predictions"] rescue []
+
+            data.map do |jt|
+                time = DateTime.parse(jt["t"])
+                DataModels::TideData.new(
+                    type: jt["type"] == "H" ? "High" : "Low",
+                    units: "ft",
+                    prediction: jt["v"].to_f,
+                    time: time,
+                    url: "https://tidesandcurrents.noaa.gov/noaatidepredictions.html?id=#{public_id}&bdate=#{time.strftime("%Y%m%d")}"
+                )
+            end
+        end
+    end
+end

--- a/data_models/station.rb
+++ b/data_models/station.rb
@@ -1,5 +1,11 @@
 module DataModels
     class Station
+
+        # When modifying this class, bump this version
+        def self.version
+            1
+        end
+
         attr_accessor :name
         attr_accessor :alternate_names
         attr_accessor :id

--- a/data_models/station.rb
+++ b/data_models/station.rb
@@ -1,0 +1,57 @@
+module DataModels
+    class Station
+        attr_accessor :name
+        attr_accessor :alternate_names
+        attr_accessor :id
+        attr_accessor :public_id
+        attr_accessor :region
+        attr_accessor :location
+        attr_accessor :lat
+        attr_accessor :lon
+        attr_accessor :url
+        attr_accessor :provider
+
+        def initialize(name:, alternate_names:, id:, public_id:, region:, location:, lat:, lon:, url:, provider:)
+            @name = name
+            @alternate_names = alternate_names
+            @id = id
+            @public_id = public_id
+            @region = region
+            @location = location
+            @lat = lat
+            @lon = lon
+            @url = url
+            @provider = provider
+        end
+
+        def to_hash
+            {
+                name: name,
+                alternate_names: alternate_names,
+                id: id,
+                public_id: public_id,
+                region: region,
+                location: location,
+                lat: lat,
+                lon: lon,
+                url: url,
+                provider: provider
+            }
+        end
+
+        def self.from_hash(h)
+            Station.new(
+                name: h['name'],
+                alternate_names: h['alternate_names'],
+                id: h['id'],
+                public_id: h['public_id'],
+                region: h['region'],
+                location: h['location'],
+                lat: h['lat'],
+                lon: h['lon'],
+                url: h['url'],
+                provider: h['provider']
+            )
+        end
+    end
+end

--- a/data_models/tide_data.rb
+++ b/data_models/tide_data.rb
@@ -1,0 +1,37 @@
+module DataModels
+    class TideData
+        attr_accessor :type
+        attr_accessor :units
+        attr_accessor :prediction
+        attr_accessor :time
+        attr_accessor :url
+        
+        def initialize(type:, units:, prediction:, time:, url:)
+            @type = type
+            @prediction = prediction
+            @time = time
+            @url = url
+            @units = units
+        end
+
+        def to_hash
+            {
+                type: type,
+                prediction: prediction,
+                time: time,
+                url: url,
+                units: units
+            }
+        end
+
+        def self.from_hash(h)
+            TideData.new(
+                type: h['type'],
+                prediction: h['prediction'],
+                time: DateTime.parse(h['time']),
+                url: h['url'],
+                units: h['units']
+            )
+        end
+    end
+end

--- a/data_models/tide_data.rb
+++ b/data_models/tide_data.rb
@@ -1,5 +1,11 @@
 module DataModels
     class TideData
+
+        # When modifying this class, bump this version
+        def self.version
+            1
+        end
+
         attr_accessor :type
         attr_accessor :units
         attr_accessor :prediction

--- a/server.rb
+++ b/server.rb
@@ -32,7 +32,6 @@ class Server < ::Sinatra::Base
         end
 
         FileUtils.mkdir_p settings.cache_dir
-        Dir.glob("#{settings.cache_dir}/*.json").each { |file| File.delete(file)}
     end
 
     configure :development do

--- a/server.rb
+++ b/server.rb
@@ -9,7 +9,6 @@
 # FIXME: fix tide event URLs to reference the right day from tz (not GMT)
 
 require 'bundler/setup'
-require 'pry'
 Bundler.require
 
 require_relative 'webcaltides'
@@ -23,14 +22,13 @@ class Server < ::Sinatra::Base
     set :static,        true
     set :public_folder, settings.root + '/public'
     set :views,         settings.root + '/views'
-    set :bind,          '0.0.0.0'
 
     configure do
         set :logging, Logger::DEBUG
         disable :sessions
 
         Timezone::Lookup.config(:geonames) do |c|
-            c.username = 'pauljschellenberg'
+            c.username = ENV['USER']
         end
 
         FileUtils.mkdir_p settings.cache_dir

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,9 +1,13 @@
 <form action="/" accept-charset="UTF-8" method="POST" class="w-50">
-    <label for="searchtext" class="form-label">Station Search <em>(use quotes for multi-word, e.g. shilshole "puget sound")</em></label>
-
+    <label for="searchtext" class="form-label">Station Search <em>(use double quotes for multi-word, e.g. shilshole "puget sound")</em></label>
     <div class="input-group">
         <span class="input-group-text" id="searchtext_prompt">Keyword or ID:</span>
-        <input type="text" class="form-control" name="searchtext" id="searchtext" placeholder="Station..."/>
+        <input type="text" class="form-control" name="searchtext" id="searchtext" placeholder=<%= params['searchtext'].nil? ? 'Station...' : params['searchtext'] %> />
+        <span class="input-group-text" id="searchtext_prompt">Units:</span>
+        <select class="form-control" name="units" id="searchunits">
+            <option value="imperial" <%= selected='selected' if params['units'] == 'imperial'%>>ft/mi</option>
+            <option value="metric" <%= selected='selected' if params['units'] == 'metric'%>>m/km</option>
+        </select>
         <button class="btn btn-primary" type="submit">Search</button>
     </div>
 </form>
@@ -31,18 +35,18 @@
 <tbody>
 <% tide_results.each do |r| %>
     <tr>
-    <th scope="row"><a href="https://tidesandcurrents.noaa.gov/stationhome.html?id=<%= r['stationId'] %>"><%= r['stationId'] %></a></th>
-    <td><%= r["commonName"] %></td>
-    <td><%= r["region"]%></td>
+    <th scope="row"><a href=<%= r.url %>><%= r.public_id %></a></th>
+    <td><%= r.name %></td>
+    <td><%= r.region%></td>
 
     <%
-       uri.path = "/tides/#{r['stationId']}.ics"
-
+       uri.path = "/tides/#{r.id}.ics"
+       uri.query = "units=#{params['units']}"
        uri.scheme = "webcal"
        webcal_url = uri.to_s
-       uri.scheme = "https"
+       uri.scheme = "http"
        https_url  = uri.to_s
-       url_id     = "url_#{r['stationId']}"
+       url_id     = "url_#{r.id}"
     %>
     <td>
 
@@ -71,8 +75,9 @@
                     <label for="within" class="form-label">Any stations within</label>
                     <div class="input-group">
                         <input type="text" class="form-control" name="within" id="within" />
-                        <input type="hidden" name="searchtext" value="<%= r['stationId'] %>" />
-                        <span class="input-group-text" id="radius_units">mi</span>
+                        <input type="hidden" name="searchtext" value="<%= r.id %>" />
+                        <input type="hidden" name="units" value="<%= params['units'] %>" />
+                        <span class="input-group-text" id="radius_units"> <%= params['units'] == 'imperial' ? 'mi' : 'km' %></span>
                         <button class="btn btn-secondary btn-sm" type="submit">Search</button>
                     </div>
                 </form>
@@ -108,7 +113,7 @@
 
     <%
        uri.path = "/currents/#{r['bid']}.ics"
-
+       uri.query = "units=#{params['units']}"
        uri.scheme = "webcal"
        webcal_url = uri.to_s
        uri.scheme = "https"
@@ -144,7 +149,8 @@
                     <div class="input-group">
                         <input type="text" class="form-control" name="within" id="within" />
                         <input type="hidden" name="searchtext" value="<%= r['bid'] %>" />
-                        <span class="input-group-text" id="radius_units">mi</span>
+                        <input type="hidden" name="units" value="<%= params['units'] %>" />
+                        <span class="input-group-text" id="radius_units"><%= params['units'] == 'imperial' ? 'mi' : 'km' %></span>
                         <button class="btn btn-secondary btn-sm" type="submit">Search</button>
                     </div>
                 </form>

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,10 +1,10 @@
-<form action="/" accept-charset="UTF-8" method="POST" class="w-50">
+<form action="/" accept-charset="UTF-8" method="POST" class="w-100">
     <label for="searchtext" class="form-label">Station Search <em>(use double quotes for multi-word, e.g. shilshole "puget sound")</em></label>
     <div class="input-group">
         <span class="input-group-text" id="searchtext_prompt">Keyword or ID:</span>
         <input type="text" class="form-control" name="searchtext" id="searchtext" placeholder=<%= params['searchtext'].nil? ? 'Station...' : params['searchtext'] %> />
         <span class="input-group-text" id="searchtext_prompt">Units:</span>
-        <select class="form-control" name="units" id="searchunits">
+        <select class="form-select" style="flex: 0.3 0.3 auto;" name="units" id="searchunits">
             <option value="imperial" <%= selected='selected' if params['units'] == 'imperial'%>>ft/mi</option>
             <option value="metric" <%= selected='selected' if params['units'] == 'metric'%>>m/km</option>
         </select>

--- a/views/index.erb
+++ b/views/index.erb
@@ -44,7 +44,7 @@
        uri.query = "units=#{params['units']}"
        uri.scheme = "webcal"
        webcal_url = uri.to_s
-       uri.scheme = "http"
+       uri.scheme = "https"
        https_url  = uri.to_s
        url_id     = "url_#{r.id}"
     %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -29,6 +29,11 @@ WebCalTides is a free service that provides tides, currents and sunrise/sunset c
     Written by <a href="mailto:jpr5@darkridge.com">Jordan Ritter</a>.  Project source at <a href="https://github.com/jpr5/webcaltides">GitHub</a>.
 </p>
 
+<button class="btn btn-primary" onclick="document.getElementById('license-acknowledgements').removeAttribute('hidden')">Show License Acknowledgements</button>
+<p hidden id="license-acknowledgements">
+    <em>This product has been produced by or for WebCalTides Service and includes data and services provided by the Canadian Hydrographic Service of the Department of Fisheries and Oceans. The incorporation of data sourced from the Canadian Hydrographic Service of the Department of Fisheries and Oceans within this product does NOT constitute an endorsement by the Canadian Hydrographic Service or the Department of Fisheries and Oceans of this product.</em>
+</p>
+
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.4/dist/umd/popper.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.min.js" integrity="sha384-pQQkAEnwaBkjpqZ8RU1fF1AKtTcHJwFl3pblpTlHXybJjHpMYo79HY3hIi4NKxyj" crossorigin="anonymous"></script>
 </body>

--- a/webcaltides.rb
+++ b/webcaltides.rb
@@ -102,7 +102,7 @@ module WebCalTides
 
     def tide_stations
         return @tide_stations ||= begin
-            filename = "#{settings.cache_dir}/tide_stations.json"
+            filename = "#{settings.cache_dir}/tide_stations_v#{DataModels::Station.version}.json"
 
             File.exists? filename or cache_tide_stations(at:filename)
 
@@ -169,7 +169,7 @@ module WebCalTides
         return nil unless station
 
         id = station.id
-        filename = "#{settings.cache_dir}/tides_#{id}_#{year}.json"
+        filename = "#{settings.cache_dir}/tide_data_v#{DataModels::TideData.version}_#{id}_#{year}.json"
         File.exists? filename or cache_tide_data_for(station, at:filename, year:year)
 
         logger.debug "reading #{filename}"


### PR DESCRIPTION
Hello,

I love your website!

I'm not the most well versed in Ruby Best Practices so feel free to rip this apart :smile: 

Sorry for doing so much in a single PR. Let me know if you want me to do this in multiple commits more iteratively

## Overview

This PR adds Canadian Tidal information to your service. API docs can be found: https://www.qc.dfo-mpo.gc.ca/tides/en/web-services-offered-canadian-hydrographic-service

To make this work, I had to do some refactoring to decouple the tidal calendars from the data model that noaa was returning. So I made a bunch of classes to hold the data and went from there.

Right now, I'm most interested in adding tidal data for Canada so I didn't look into any current data providers. So I left all of the current data untouched.

### Changes
- added classes to hold common station and tidal data attributes between providers
- moved all of the noaa tide api calls to a noaa_client
- created a chs client for canadian tidal data
- added selectable units
- updated index.erb to retain the last searched data with the last used units when re-rendering it
- There was a bug where if you provided a mix of single and double quotes in the search, it wouldn't tokenize properly
  - `"Hudson's Bay"` would tokenize to ["hudson", "bay"] or something
  - I made it so that only double quotes can be used for this since I was too lazy to fix it properly

## Testing

### Unchanged Old Functionality

Since there aren't any unit tests, I did a sanity check on the ics files to make sure that none of the important information has changed

I downloaded an ics file for seattle before my change and an ics file for seattle after my change. I got rid of the unique fields that are associated with the creation of the files and then I diffed them. It came up empty so the files are identical

```
cat '9447130.ics' | grep -v UID | grep -v DTSTAMP > /tmp/seattle_old.ics
cat '9447130(1).ics' | grep -v UID | grep -v DTSTAMP > /tmp/seattle_new.ics
cd /tmp
git diff --ignore-space-change seattle_old.ics seattle_new.ics
```

### Radius Search
Searching by radius will capture both Canada and American tidal stations

### Canadian tidal information
Downloaded the ics file for victoria and verified with the canadian government tidal website for a few days in the year to make sure that everything is good.

Can click on the station id link in the table to go to the gov website as well. 