### PR TITLE
Harden CI: SHA-pin actions, add persist-credentials: false

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,17 +7,21 @@ on:
     branches: [master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
         with:
           ruby-version: '3.2'
           bundler-cache: true
@@ -31,7 +35,7 @@ jobs:
           RACK_ENV: test
 
       - name: Archive coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: coverage-report


### PR DESCRIPTION
## Summary

- SHA-pin `actions/checkout`, `ruby/setup-ruby`, and `actions/upload-artifact` to their current commit SHAs to prevent supply-chain attacks via tag mutation
- Add `persist-credentials: false` to the checkout step so the GITHUB_TOKEN is not persisted in the local git config
- Add top-level `permissions: contents: read` to enforce least-privilege on the workflow's GITHUB_TOKEN

## Test plan

- [ ] Verify CI passes on this PR (all three pinned actions resolve correctly)
- [ ] Confirm `bundle exec rspec` still runs and coverage artifact uploads