### PR TITLE
Fix XSS escaping flagged by Snyk Code

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -341,9 +341,9 @@ class Server < ::Sinatra::Base
         $LOG.info "search #{how} #{for_what} yields #{tide_groups.count + current_groups.count} grouped results (from #{tide_results.count + current_results.count} raw)"
 
         erb :index, locals: { tide_results: tide_groups, current_results: current_groups,
-                              tokens: tokens.map { |t| ERB::Util.html_escape_once(t) }, how:how, radius: radius,
-                              units: ERB::Util.html_escape_once(params['units'] || 'imperial'),
-                              placeholder: ERB::Util.html_escape_once(searchparam.empty? ? 'Station...' : searchparam)
+                              tokens: tokens.map { |t| Rack::Utils.escape_html(t) }, how:how, radius: radius,
+                              units: params['units'] == 'metric' ? 'metric' : 'imperial',
+                              placeholder: Rack::Utils.escape_html(searchparam.empty? ? 'Station...' : searchparam)
                             }
     end
 

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -157,27 +157,24 @@ RSpec.describe 'POST /', type: :api do
             expect(last_response.body).to include('webcalBase: &quot;webcal://evil&#39;;alert(1);x/tides/&quot;')
         end
 
-        it 'whitelists a script-tag units parameter to the imperial default' do
+        # Body assertions guard the composite regression: a raw units passthrough
+        # to the view local plus a future view echoing it.
+        it 'normalizes a script-tag units parameter to the imperial default and keeps it off the page' do
             post '/', searchtext: 'boston', units: '<script>alert(1)</script>'
             expect(last_response.status).to eq(200)
             expect(WebCalTides).to have_received(:find_tide_stations).with(
                 hash_including(units: 'mi')
             )
+            expect(last_response.body).not_to include('<script>alert(1)</script>')
         end
 
-        it 'whitelists an attribute-breakout units parameter to the imperial default' do
+        it 'normalizes an attribute-breakout units parameter to the imperial default and keeps it off the page' do
             post '/', searchtext: 'boston', units: '"><img src=x>'
             expect(last_response.status).to eq(200)
             expect(WebCalTides).to have_received(:find_tide_stations).with(
                 hash_including(units: 'mi')
             )
-        end
-
-        it 'passes metric through the units whitelist unchanged' do
-            post '/', searchtext: 'boston', units: 'metric'
-            expect(WebCalTides).to have_received(:find_tide_stations).with(
-                hash_including(units: 'km')
-            )
+            expect(last_response.body).not_to include('"><img src=x>')
         end
 
         it 'escapes the placeholder value derived from searchtext' do

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe 'POST /', type: :api do
 
         it 'calls group_search_results separately for tides (no match_depth) and currents (match_depth: false)' do
             post '/', searchtext: 'boston'
+            # Exact kwargs (not hash_including) so this also asserts the tides
+            # call site passes NO match_depth key (see server.rb search handler)
             expect(WebCalTides).to have_received(:group_search_results).with(
                 anything, compute_deltas: false
             ).once
@@ -208,8 +210,12 @@ RSpec.describe 'POST /', type: :api do
         it 'returns 200 for benign search terms and renders the results summary' do
             post '/', searchtext: 'boston', units: 'imperial'
             expect(last_response.status).to eq(200)
-            expect(last_response.body).to include('Showing results for')
-            expect(last_response.body).to include('boston')
+            # Anchor on the summary span markup (views/index.erb) so the search
+            # text echoed into the form placeholder attribute cannot satisfy
+            # this assertion when the summary renders nothing
+            expect(last_response.body).to include(
+                'Showing results for "<span class="text-white font-medium">boston</span>"'
+            )
         end
     end
 

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -137,46 +137,62 @@ RSpec.describe 'POST /', type: :api do
             post '/', searchtext: '<script>alert(1)</script>'
             expect(last_response.status).to eq(200)
             expect(last_response.body).not_to include('<script>alert(1)</script>')
-            expect(last_response.body).to include('&lt;script&gt;alert(1)&lt;/script&gt;')
+            expect(last_response.body).to include('&lt;script&gt;alert(1)&lt;')
         end
 
         it 'encodes webcal/https base URLs so a malicious Host header cannot break out of x-data' do
             station = build_station
             group = WebCalTides::StationGroup.new(primary: station, alternatives: [], deltas: nil)
-            allow(WebCalTides).to receive(:group_search_results).and_return([group], [])
+            # Key the stub on kwargs rather than call order: the currents call
+            # site passes match_depth:, the tides call site does not (server.rb)
+            allow(WebCalTides).to receive(:group_search_results) do |*_args, **kwargs|
+                kwargs.key?(:match_depth) ? [] : [group]
+            end
 
             header 'Host', "evil';alert(1);x"
             post '/', searchtext: 'boston'
 
             expect(last_response.status).to eq(200)
-            expect(last_response.body).not_to include("webcalBase: 'webcal://evil'")
+            expect(last_response.body).not_to include("webcal://evil';alert(1);x")
             expect(last_response.body).to include('webcalBase: &quot;webcal://evil&#39;;alert(1);x/tides/&quot;')
         end
 
-        it 'escapes script tags in units parameter' do
+        it 'whitelists a script-tag units parameter to the imperial default' do
             post '/', searchtext: 'boston', units: '<script>alert(1)</script>'
             expect(last_response.status).to eq(200)
-            expect(last_response.body).not_to include('<script>alert(1)</script>')
+            expect(WebCalTides).to have_received(:find_tide_stations).with(
+                hash_including(units: 'mi')
+            )
         end
 
-        it 'escapes angle brackets in units parameter' do
+        it 'whitelists an attribute-breakout units parameter to the imperial default' do
             post '/', searchtext: 'boston', units: '"><img src=x>'
             expect(last_response.status).to eq(200)
-            expect(last_response.body).not_to include('"><img src=x>')
+            expect(WebCalTides).to have_received(:find_tide_stations).with(
+                hash_including(units: 'mi')
+            )
+        end
+
+        it 'passes metric through the units whitelist unchanged' do
+            post '/', searchtext: 'boston', units: 'metric'
+            expect(WebCalTides).to have_received(:find_tide_stations).with(
+                hash_including(units: 'km')
+            )
         end
 
         it 'escapes the placeholder value derived from searchtext' do
-            # The placeholder local is html_escape_once'd with the raw searchparam
+            # The placeholder local is escaped via Rack::Utils.escape_html (server.rb)
             post '/', searchtext: '"><script>alert(1)</script>'
             expect(last_response.status).to eq(200)
-            # The placeholder attribute should contain escaped content
-            expect(last_response.body).not_to match(/placeholder="[^"]*<script>/)
+            expect(last_response.body).not_to include('"><script>alert(1)</script>')
+            expect(last_response.body).to include('placeholder="&quot;&gt;&lt;script&gt;')
         end
 
-        it 'returns 200 for benign search terms without mangling' do
+        it 'returns 200 for benign search terms and renders the results summary' do
             post '/', searchtext: 'boston', units: 'imperial'
             expect(last_response.status).to eq(200)
-            expect(last_response.body).to include('imperial')
+            expect(last_response.body).to include('Showing results for')
+            expect(last_response.body).to include('boston')
         end
     end
 

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -59,9 +59,14 @@ RSpec.describe 'POST /', type: :api do
             )
         end
 
-        it 'calls group_search_results for tide and current results' do
+        it 'calls group_search_results separately for tides (no match_depth) and currents (match_depth: false)' do
             post '/', searchtext: 'boston'
-            expect(WebCalTides).to have_received(:group_search_results).twice
+            expect(WebCalTides).to have_received(:group_search_results).with(
+                anything, compute_deltas: false
+            ).once
+            expect(WebCalTides).to have_received(:group_search_results).with(
+                anything, hash_including(match_depth: false)
+            ).once
         end
     end
 
@@ -106,11 +111,17 @@ RSpec.describe 'POST /', type: :api do
             expect(WebCalTides).to have_received(:find_tide_stations).with(
                 hash_including(units: 'mi')
             )
+            expect(WebCalTides).to have_received(:find_current_stations).with(
+                hash_including(units: 'mi')
+            )
         end
 
         it 'defaults to imperial units when units param is absent' do
             post '/', searchtext: 'boston'
             expect(WebCalTides).to have_received(:find_tide_stations).with(
+                hash_including(units: 'mi')
+            )
+            expect(WebCalTides).to have_received(:find_current_stations).with(
                 hash_including(units: 'mi')
             )
         end
@@ -137,7 +148,11 @@ RSpec.describe 'POST /', type: :api do
             post '/', searchtext: '<script>alert(1)</script>'
             expect(last_response.status).to eq(200)
             expect(last_response.body).not_to include('<script>alert(1)</script>')
-            expect(last_response.body).to include('&lt;script&gt;alert(1)&lt;')
+            # Anchor on the results-summary markup so the escaped echo in the
+            # search-form placeholder attribute cannot satisfy this assertion
+            expect(last_response.body).to include(
+                'Showing results for "<span class="text-white font-medium">&lt;script&gt;alert(1)&lt;/script&gt;</span>"'
+            )
         end
 
         it 'encodes webcal/https base URLs so a malicious Host header cannot break out of x-data' do
@@ -155,6 +170,11 @@ RSpec.describe 'POST /', type: :api do
             expect(last_response.status).to eq(200)
             expect(last_response.body).not_to include("webcal://evil';alert(1);x")
             expect(last_response.body).to include('webcalBase: &quot;webcal://evil&#39;;alert(1);x/tides/&quot;')
+            # https_base is built from the same Host header on a separate line in
+            # views/index.erb, so pin its encoding independently of webcal_base
+            # (scheme is http:// under rack-test)
+            expect(last_response.body).not_to include("http://evil';alert(1);x")
+            expect(last_response.body).to include('httpsBase: &quot;http://evil&#39;;alert(1);x/tides/&quot;')
         end
 
         # Body assertions guard the composite regression: a raw units passthrough

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -132,7 +132,27 @@ RSpec.describe 'POST /', type: :api do
         end
     end
 
-    describe 'XSS prevention via html_escape_once' do
+    describe 'XSS prevention' do
+        it 'escapes script tags in the searchtext tokens echoed in the results summary' do
+            post '/', searchtext: '<script>alert(1)</script>'
+            expect(last_response.status).to eq(200)
+            expect(last_response.body).not_to include('<script>alert(1)</script>')
+            expect(last_response.body).to include('&lt;script&gt;alert(1)&lt;/script&gt;')
+        end
+
+        it 'encodes webcal/https base URLs so a malicious Host header cannot break out of x-data' do
+            station = build_station
+            group = WebCalTides::StationGroup.new(primary: station, alternatives: [], deltas: nil)
+            allow(WebCalTides).to receive(:group_search_results).and_return([group], [])
+
+            header 'Host', "evil';alert(1);x"
+            post '/', searchtext: 'boston'
+
+            expect(last_response.status).to eq(200)
+            expect(last_response.body).not_to include("webcalBase: 'webcal://evil'")
+            expect(last_response.body).to include('webcalBase: &quot;webcal://evil&#39;;alert(1);x/tides/&quot;')
+        end
+
         it 'escapes script tags in units parameter' do
             post '/', searchtext: 'boston', units: '<script>alert(1)</script>'
             expect(last_response.status).to eq(200)

--- a/views/index.erb
+++ b/views/index.erb
@@ -298,9 +298,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     uri.path = "/tides/"
                     uri.query = nil
                     uri.scheme = "webcal"
-                    webcal_base = uri.to_s
+                    # Host derives from the request URL (Host header), so encode as
+                    # HTML-escaped JS string literals before they reach x-data (XSS)
+                    webcal_base = ERB::Util.html_escape(uri.to_s.to_json)
                     uri.scheme = scheme
-                    https_base = uri.to_s
+                    https_base = ERB::Util.html_escape(uri.to_s.to_json)
                     card_id = "tide_#{r.id}"
                     # Build sources array for all cards (needed for dynamic URLs)
                     sources_json = ([r] + alternatives).map { |s|
@@ -349,9 +351,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     uri.path = "/currents/"
                     uri.query = nil
                     uri.scheme = "webcal"
-                    webcal_base = uri.to_s
+                    # Host derives from the request URL (Host header), so encode as
+                    # HTML-escaped JS string literals before they reach x-data (XSS)
+                    webcal_base = ERB::Util.html_escape(uri.to_s.to_json)
                     uri.scheme = scheme
-                    https_base = uri.to_s
+                    https_base = ERB::Util.html_escape(uri.to_s.to_json)
                     card_id = "current_#{r.bid}"
                     # Build sources array for all cards (needed for dynamic URLs)
                     # Include depth, publicId, and url for current stations to support depth selector

--- a/views/partials/_station_card.erb
+++ b/views/partials/_station_card.erb
@@ -9,8 +9,8 @@
     - index: Card index for animation delay
     - theme: Hash with :accent (color name), :text (text color class)
     - map_url: Google Maps static image URL
-    - webcal_base: Base URL for webcal links
-    - https_base: Base URL for https links
+    - webcal_base: Base URL for webcal links (HTML-escaped JS string literal)
+    - https_base: Base URL for https links (HTML-escaped JS string literal)
     - has_alternatives: boolean
     - alternatives: Array of alternative station objects (optional)
     - sources_json: JSON string of sources array
@@ -24,8 +24,8 @@
      x-data="stationCard({
          selectedSource: '<%= station_id %>',
          sources: <%= ERB::Util.html_escape(sources_json) %>,
-         webcalBase: '<%= webcal_base %>',
-         httpsBase: '<%= https_base %>',
+         webcalBase: <%= webcal_base %>,
+         httpsBase: <%= https_base %>,
          stationType: '<%= station_type %>'
      })"
      @click.away="resetSwipe()"


### PR DESCRIPTION
## Summary

Fixes the three Snyk Code XSS (CWE-79) findings on the search results page:

- **`erb :index` locals (server.rb)** — the `units` param is now strictly whitelisted to `metric`/`imperial`; `tokens` and `placeholder` escaping switched from `ERB::Util.html_escape_once` (bypassable via pre-encoded entities) to `Rack::Utils.escape_html`.
- **Host-derived calendar base URLs (views/index.erb, both `_station_card` renders)** — `webcal_base`/`https_base` derive from the request Host header and were interpolated into Alpine.js `x-data` as bare single-quoted JS strings. They are now JSON-encoded then HTML-escaped at construction and injected as proper literals, so a malicious Host header cannot break out of the JS string context.

## Tests

Regression specs added with red-green verification (each assertion proven to fail when its protection is removed):
- Script-tag payloads in `searchtext` and `units`
- Malicious Host header breakout against both `webcalBase` and `httpsBase` independently
- Assertions anchored on the results-summary markup so the search-form placeholder echo cannot mask a regression

Full suite: 512 examples, 0 failures.