### PR TITLE
Bump puma 6.6.0 -> 7.2.1 past Snyk High advisories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'rack', '>= 3.2.6'
 gem 'rack-session', '>= 2.1.2'
 gem 'rackup', '>= 2.2.0'
 gem 'webrick', '>= 1.8.2'
-gem 'puma', '>= 6.6.0'
+gem 'puma', '~> 7.2', '>= 7.2.1'
 gem 'sinatra', '~> 4.2.1', require: 'sinatra/base'
 
 gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.6)
       connection_pool (~> 2.2, >= 2.2.4)
-    nio4r (2.7.4)
+    nio4r (2.7.5)
     nkf (0.2.0)
     nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
@@ -96,7 +96,7 @@ GEM
     psych (5.1.2)
       stringio
     public_suffix (7.0.5)
-    puma (6.6.0)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -188,7 +188,7 @@ DEPENDENCIES
   nokogiri (>= 1.19.3)
   openssl (>= 3.1.2)
   pry
-  puma (>= 6.6.0)
+  puma (~> 7.2, >= 7.2.1)
   rack (>= 3.2.6)
   rack-session (>= 2.1.2)
   rack-test (~> 2.1)


### PR DESCRIPTION
## Summary

Bumps puma from 6.6.0 to 7.2.1 to clear two Snyk High advisories that cannot be auto-PR'd. Both are in puma's PROXY protocol v1 parser, only exploitable when the server is configured with `set_remote_address proxy_protocol: :v1`. We don't enable that, so we aren't directly exploitable — but the bump clears the scan.

## Advisories resolved

| Advisory | CVE | GHSA | Snyk | Severity | Fix |
|---|---|---|---|---|---|
| User Impersonation via PROXY v1 spoofing on persistent connections | CVE-2026-47737 | GHSA-2vqw-3mp8-cgmx | SNYK-RUBY-PUMA-17220028 | High (CVSS 8.7, CWE-290) | 7.2.1 |
| Allocation of Resources Without Limits or Throttling — unbounded memory growth via PROXY v1 parser missing CRLF terminator | CVE-2026-47736 | GHSA-qpgp-93vx-g8v8 | SNYK-RUBY-PUMA-17219754 | High (CVSS 7.5, CWE-400/770) | 7.2.1 |

Both are also fixed in 8.0.2 on the 8.x line. Pinned to `~> 7.2, >= 7.2.1` to minimize churn; the 8.x bump is deferred.

## Version delta (6.6.0 -> 7.2.1)

Notable changes across the range:

- **6.6.1** (Jul 2025) — `rack.after_reply` chain error handling, better HttpParserError messages.
- **7.0.0** (Sep 2025) — major version, multiple breaking changes (see audit below). Fiber-per-request, `rack.response_finished`, custom logger.
- **7.0.1 / 7.0.2 / 7.0.3 / 7.0.4** — backward-compat aliases, control CLI fixes, perf, SSL shutdown error handling, header whitespace stripping.
- **7.1.0** (Oct 2025) — `after_worker_shutdown` hook, restores faster keepalive inline pipelining.
- **7.2.0** (Jan 2026) — `workers :auto`, stats-only control server mode.
- **7.2.1** (May 2026) — security fixes for the two advisories above.

## Puma 7.0 breaking-change audit against this repo

| Breaking change | Status |
|---|---|
| Hook rename (e.g. `on_worker_boot` -> `before_worker_boot`) | n/a — `workers 0`, no hooks defined |
| `HTTP_VERSION` no longer set for Rack > 3.1 | not referenced in repo |
| `ruby_engine` removed from Runner | not referenced |
| Default bind `0.0.0.0` -> `::` (IPv6) | we set `port` / `bind` explicitly |
| `preload_app!` default in clustered mode | n/a — single mode (`workers 0`) |
| Response headers lowercased | downstream of Sinatra/Rack, no app dependency on case |
| Min Ruby raised to 3.0 | repo requires `ruby '~> 3.2'` |

`puma.rb` config keys still supported: `log_requests`, `workers`, `threads`, `raise_exception_on_sigterm`, `force_shutdown_after`, `port`, `bind`, `stdout_redirect`.

## Verification

- `bundle exec rspec` — **512 examples, 0 failures** (matches post-#45 baseline)
- Smoke boot: `bundle exec puma -p 4567 -e test` -> `Puma version: 7.2.1 ("On The Corner")`, `curl http://localhost:4567/` returns HTTP 200 (49583 bytes)

## Scope

Only Gemfile + Gemfile.lock. Adjacent dependabot/Snyk findings (if any) are deferred to follow-ups.